### PR TITLE
changes field "reading" to "amount" in power json encoding

### DIFF
--- a/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
+++ b/src/main/scala/com/tw/energy/domain/ElectricityReading.scala
@@ -13,14 +13,14 @@ trait SquantsJsonSupport {
   implicit val moneyContext: MoneyContext = defaultMoneyContext
 
   implicit val encodePower: Encoder[Power] = (power: Power) => Json.obj(
-    ("reading", Json.fromDouble(power.value).getOrElse(Json.Null)),
+    ("amount", Json.fromDouble(power.value).getOrElse(Json.Null)),
     ("unit", Json.fromString(power.unit.symbol))
   )
 
   implicit val decodePower: Decoder[Power] = (c: HCursor) => for {
-    reading <- c.downField("reading").as[Double]
+    amount <- c.downField("amount").as[Double]
     unit <- c.downField("unit").as[String]
-    power <- Power((reading, unit)).fold(ex => Left(DecodingFailure.fromThrowable(ex, c.history)), power => Right(power))
+    power <- Power((amount, unit)).fold(ex => Left(DecodingFailure.fromThrowable(ex, c.history)), power => Right(power))
   } yield {
     power
   }

--- a/src/test/scala/com/tw/energy/controller/MeterReadingControllerTest.scala
+++ b/src/test/scala/com/tw/energy/controller/MeterReadingControllerTest.scala
@@ -14,7 +14,7 @@ class MeterReadingControllerTest extends AnyFlatSpec with Matchers with Scalates
   val time = "2019-01-24T18:11:27.142Z"
   val reading = Kilowatts(0.6)
   val smartMeterId = "validId"
-  val jsonElectricityReadings = s"""[{"time":"$time","reading":{"reading":0.6,"unit":"kW"}}]"""
+  val jsonElectricityReadings = s"""[{"time":"$time","reading":{"amount":0.6,"unit":"kW"}}]"""
   val jsonMeterReadings = s"""{"smartMeterId":"$smartMeterId","electricityReadings":$jsonElectricityReadings}"""
 
 

--- a/src/test/scala/com/tw/energy/domain/SquantsJsonSupportTest.scala
+++ b/src/test/scala/com/tw/energy/domain/SquantsJsonSupportTest.scala
@@ -61,7 +61,7 @@ class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks 
     "should decode instance of power:" - {
       val inputs =
         Table(
-          ("reading", "unit", "result"),
+          ("amount", "unit", "result"),
           (1, "W", Watts(1)),
           (-1, "W", Watts(-1)),
           (100.2, "W", Watts(100.20)),
@@ -72,9 +72,9 @@ class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks 
           (1000000.243, "kW", Kilowatts(1000000.243)),
         )
 
-      forAll(inputs) { (reading: Any, unit: String, expected: Power) =>
-        s"should decode $reading $unit" in {
-          val input = s"""{ "reading": $reading, "unit": "$unit" }"""
+      forAll(inputs) { (amount: Any, unit: String, expected: Power) =>
+        s"should decode $amount $unit" in {
+          val input = s"""{ "amount": $amount, "unit": "$unit" }"""
           import org.scalatest.EitherValues._
           decode[Power](input).value shouldBe (expected)
         }
@@ -84,7 +84,7 @@ class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks 
     "should encode instance of power:" - {
       val inputs =
         Table(
-          ("power", "reading", "unit"),
+          ("power", "amount", "unit"),
           (Watts(1),"1.0", "W"),
           (Watts(-1) ,"-1.0", "W"),
           (Watts(100.20) ,"100.2", "W"),
@@ -95,11 +95,11 @@ class SquantsJsonSupportTest extends AnyFreeSpec with TableDrivenPropertyChecks 
           (Kilowatts(1000000.243) ,"1000000.243", "kW"),
         )
 
-      forAll(inputs) { (power: Power, reading: String, unit: String) =>
-        s"should encode $reading $unit" in {
+      forAll(inputs) { (power: Power, amount: String, unit: String) =>
+        s"should encode $amount $unit" in {
           val expected =
             s"""{
-               |  "reading" : $reading,
+               |  "amount" : $amount,
                |  "unit" : "$unit"
                |}""".stripMargin
           power.asJson.toString should equal(expected)


### PR DESCRIPTION
Changes the name of the "value" field from "reading" to "amount", in order to decouple from the meter context.